### PR TITLE
Dump all unsubscribed events to `unsubscribed.event`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Include package in Hubot's `external-scripts.json`:
   - Content-Type: `application/json`
   - Body: `{ "password": "optional", "event": "event", "data": "text" }`
 
+### Handling unsubscribed events
+
+Do `hubot subscribe unsubscribed.event` in a room where you want all unrouted events to get announced.
 
 ### Issues
 

--- a/spec/pubsub_spec.coffee
+++ b/spec/pubsub_spec.coffee
@@ -95,3 +95,19 @@ describe 'pubsub', ->
 
     say 'hubot unsubscribe foo.bar'
 
+  it 'allows subscribing all unsubscribed events for debugging', (done) ->
+    robot.brain.data.subscriptions = 'unsubscribed.event': [ '#jasmine' ]
+
+    count = 0
+    captured = []
+
+    doneLatch = ->
+      count += 1
+      if count == 2
+        (expect 'unsubscribed.event: unrouted: no one should receive it' in captured).toBeTruthy()
+        (expect 'Notified 0 rooms about unrouted' in captured).toBeTruthy()
+        done()
+
+    captureHubotOutput captured, doneLatch
+
+    say 'hubot publish unrouted no one should receive it'

--- a/src/pubsub.coffee
+++ b/src/pubsub.coffee
@@ -10,7 +10,7 @@
 #   HUBOT_SUBSCRIPTIONS_PASSWORD (optional)
 #
 # Commands:
-#   hubot subscribe <event> - subscribes current room to event
+#   hubot subscribe <event> - subscribes current room to event. To debug, subscribe to 'unsubscribed.event'
 #   hubot unsubscribe <event> - unsubscribes current room from event
 #   hubot unsubscribe all events - unsubscribes current room from all events
 #   hubot subscriptions - show subscriptions of current room
@@ -44,6 +44,12 @@ module.exports = (robot) ->
         user = {}
         user.room = room
         robot.send user, "#{event}: #{data}"
+    unless count > 0
+      console.log "hubot-pubsub: unsubscribed.event: #{event}: #{data}"
+      for room in subscriptions('unsubscribed.event')
+        user = {}
+        user.room = room
+        robot.send user, "unsubscribed.event: #{event}: #{data}"
     count
 
   persist = (subscriptions) ->


### PR DESCRIPTION
Do `hubot subscribe unsubscribed.event` and see what is being published in to the void.
