### PR TITLE
Send event data as JSon object

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Include package in Hubot's `external-scripts.json`:
 
     HUBOT_SUBSCRIPTIONS_PASSWORD   # Optional password for protecting HTTP API calls
     HUBOT_PUBSUB_SEND_EVENT_NAME   # Optional boolean determines whether the event name is prefixed on delivered messages (defaults to true)
+    HUBOT_PUBSUB_DATA_AS_JSON      # Optional boolean determines whether the event data is parsed as a JSON object 
+                                   # and sent as such (defaults to false)
+                                   # Useful to post to a Slack channel with rich formatting and attachments
 
 ## Commands
 

--- a/src/pubsub.coffee
+++ b/src/pubsub.coffee
@@ -30,7 +30,8 @@
 
 
 Options =
-  sendEventName:  process.env.HUBOT_PUBSUB_SEND_EVENT_NAME == "true" or not process.env.HUBOT_PUBSUB_SEND_EVENT_NAME?
+  sendEventName: process.env.HUBOT_PUBSUB_SEND_EVENT_NAME == "true" or not process.env.HUBOT_PUBSUB_SEND_EVENT_NAME?
+  dataAsJSon:    process.env.HUBOT_PUBSUB_DATA_AS_JSON    == "true" or     process.env.HUBOT_PUBSUB_DATA_AS_JSON?
 
 module.exports = (robot) ->
 
@@ -54,6 +55,12 @@ module.exports = (robot) ->
         subs[ev] ||= []
     else
       subs
+
+  messageFormatter = (event, data) ->
+    if Options.dataAsJSon
+      message = JSON.parse(data)
+    else
+      message = if Options.sendEventName then "#{event}: #{data}" else "#{data}"
 
   notify = (event, data) ->
     count = 0


### PR DESCRIPTION
Add ability to send event data as a JSon object. This fixes #13.
This is governed by HUBOT_PUBSUB_DATA_AS_JSON  environment variable which defaults to false to preserve current behavior.

Example usage when posting an event through pubsub with Hubot in a Slack channel:
![image](https://cloud.githubusercontent.com/assets/5385290/21673158/991d0746-d327-11e6-9b8c-f22e893f56df.png)

This is achieved with this curl command:
```
curl -H "Content-Type: application/json" -X POST -d '{"event":"nagios","data":"'\
'{\"text\":\"'"${ICON} ${ICINGA_SERVICEDISPLAYNAME}"' is in '"${ICINGA_SERVICESTATE}"' condition. More details <http://monitoring.microservice.io/cgi-bin/icinga/status.cgi?host='"${ICINGA_HOSTNAME}"'|here>\",'\
'\"attachments\":'\
'[{ \"title\": \"Details\", \"fields\":[{\"title\":\"Host\",\"value\":\"'${ICINGA_HOSTNAME}'\",\"short\":\"true\"},'\
'{\"title\":\"Service\",\"value\":\"'"${ICINGA_SERVICEDISPLAYNAME}"'\",\"short\":\"true\"}'\
'], \"text\": \"'"${ICINGA_SERVICEOUTPUT}"'\", \"color\":\"'"${COLOR}"'\" }'\
']'\
'}"}' \
http://my.hubot:8888/publish
```